### PR TITLE
Fix some synthesis recipes having invalid types

### DIFF
--- a/src/main/resources/data/magicksaddon/synthesis/aqua_chaplet.json
+++ b/src/main/resources/data/magicksaddon/synthesis/aqua_chaplet.json
@@ -19,7 +19,7 @@
     }
   ],
   "output": {
-    "type": "armor",
+    "type": "item",
     "item": "magicksaddon:aqua_chaplet",
     "quantity": 1
   },

--- a/src/main/resources/data/magicksaddon/synthesis/breakthrough.json
+++ b/src/main/resources/data/magicksaddon/synthesis/breakthrough.json
@@ -19,7 +19,7 @@
     }
   ],
   "output": {
-    "type": "accessory",
+    "type": "item",
     "item": "magicksaddon:breakthrough",
     "quantity": 1
   },

--- a/src/main/resources/data/magicksaddon/synthesis/celestriad.json
+++ b/src/main/resources/data/magicksaddon/synthesis/celestriad.json
@@ -19,7 +19,7 @@
     }
   ],
   "output": {
-    "type": "accessory",
+    "type": "item",
     "item": "magicksaddon:celestriad",
     "quantity": 1
   },

--- a/src/main/resources/data/magicksaddon/synthesis/crystal_regalia.json
+++ b/src/main/resources/data/magicksaddon/synthesis/crystal_regalia.json
@@ -19,7 +19,7 @@
     }
   ],
   "output": {
-    "type": "accessory",
+    "type": "item",
     "item": "magicksaddon:crystal_regalia",
     "quantity": 1
   },

--- a/src/main/resources/data/magicksaddon/synthesis/crystal_regalia_plus.json
+++ b/src/main/resources/data/magicksaddon/synthesis/crystal_regalia_plus.json
@@ -19,7 +19,7 @@
     }
   ],
   "output": {
-    "type": "accessory",
+    "type": "item",
     "item": "magicksaddon:crystal_regalia_plus",
     "quantity": 1
   },

--- a/src/main/resources/data/magicksaddon/synthesis/flanniversary_badge.json
+++ b/src/main/resources/data/magicksaddon/synthesis/flanniversary_badge.json
@@ -19,7 +19,7 @@
     }
   ],
   "output": {
-    "type": "accessory",
+    "type": "item",
     "item": "magicksaddon:flanniversary_badge",
     "quantity": 1
   },

--- a/src/main/resources/data/magicksaddon/synthesis/forest_clasp.json
+++ b/src/main/resources/data/magicksaddon/synthesis/forest_clasp.json
@@ -15,7 +15,7 @@
     }
   ],
   "output": {
-    "type": "accessory",
+    "type": "item",
     "item": "magicksaddon:forest_clasp",
     "quantity": 1
   },

--- a/src/main/resources/data/magicksaddon/synthesis/heros_belt.json
+++ b/src/main/resources/data/magicksaddon/synthesis/heros_belt.json
@@ -19,7 +19,7 @@
     }
   ],
   "output": {
-    "type": "armor",
+    "type": "item",
     "item": "magicksaddon:heros_belt",
     "quantity": 1
   },

--- a/src/main/resources/data/magicksaddon/synthesis/heros_glove.json
+++ b/src/main/resources/data/magicksaddon/synthesis/heros_glove.json
@@ -19,7 +19,7 @@
     }
   ],
   "output": {
-    "type": "armor",
+    "type": "item",
     "item": "magicksaddon:heros_glove",
     "quantity": 1
   },

--- a/src/main/resources/data/magicksaddon/synthesis/laughter_pin.json
+++ b/src/main/resources/data/magicksaddon/synthesis/laughter_pin.json
@@ -15,7 +15,7 @@
     }
   ],
   "output": {
-    "type": "accessory",
+    "type": "item",
     "item": "magicksaddon:laughter_pin",
     "quantity": 1
   },

--- a/src/main/resources/data/magicksaddon/synthesis/master_belt.json
+++ b/src/main/resources/data/magicksaddon/synthesis/master_belt.json
@@ -23,7 +23,7 @@
     }
   ],
   "output": {
-    "type": "armor",
+    "type": "item",
     "item": "magicksaddon:master_belt",
     "quantity": 1
   },

--- a/src/main/resources/data/magicksaddon/synthesis/mickey_clasp.json
+++ b/src/main/resources/data/magicksaddon/synthesis/mickey_clasp.json
@@ -15,7 +15,7 @@
     }
   ],
   "output": {
-    "type": "accessory",
+    "type": "item",
     "item": "magicksaddon:mickey_clasp",
     "quantity": 1
   },

--- a/src/main/resources/data/magicksaddon/synthesis/ultima_ribbon.json
+++ b/src/main/resources/data/magicksaddon/synthesis/ultima_ribbon.json
@@ -35,7 +35,7 @@
     }
   ],
   "output": {
-    "type": "armor",
+    "type": "item",
     "item": "magicksaddon:ultima_ribbon",
     "quantity": 1
   },


### PR DESCRIPTION
Fixes issue where most of the synthesis recipes for armors and accessories had armor/accessory as their type rather than item, leading those recipes to be unobtainable (you'd just get "No more recipes to learn" after unlocking all other recipes on the tier).