### PR TITLE
Fix error with mixin plugin

### DIFF
--- a/src/main/java/online/remind/remind/mixin/KKRMMixinPlugin.java
+++ b/src/main/java/online/remind/remind/mixin/KKRMMixinPlugin.java
@@ -16,8 +16,7 @@ public class KKRMMixinPlugin implements IMixinConfigPlugin {
     private static final Supplier<Boolean> EFMLOADED = () -> LoadingModList.get().getModFileById("epicfight") != null;
 
     private static final Map<String, Supplier<Boolean>> CONDITIONS = ImmutableMap.of(
-            "online.remind.remind.mixin.GuardSkillMixin",EFMLOADED,
-            "online.remind.remind.mixin.KKDriveFormMixin",null
+            "online.remind.remind.mixin.GuardSkillMixin",EFMLOADED
     );
     @Override
     public void onLoad(String s) {


### PR DESCRIPTION
Fixes this:
Error loading companion plugin class [online.remind.remind.mixin.KKRMMixinPlugin]
The conditions map only needs mixins that are optional, since KK must be loaded the KKDriveFormMixin doesn't need to be checked in the plugin
