### PR TITLE
Move EFM stuff into separate class to avoid class loading errors

### DIFF
--- a/src/main/java/online/remind/remind/KingdomKeysReMind.java
+++ b/src/main/java/online/remind/remind/KingdomKeysReMind.java
@@ -34,6 +34,7 @@ import online.remind.remind.effect.ModEffects;
 import online.remind.remind.entity.ModEntitiesRM;
 import online.remind.remind.handler.EntityEventsRM;
 import online.remind.remind.handler.InputHandlerRM;
+import online.remind.remind.integration.epicfight.EpicFightEvents;
 import online.remind.remind.integration.epicfight.skills.KKRMSkills;
 import online.remind.remind.item.ModItemsRM;
 import online.remind.remind.lib.ListsRM;
@@ -93,6 +94,7 @@ public class KingdomKeysReMind {
         if (ModList.get().isLoaded("epicfight")) {
             efmLoaded = true;
             KKRMSkills.SKILLS.register(modEventBus);
+            MinecraftForge.EVENT_BUS.register(new EpicFightEvents());
         }
     }
 

--- a/src/main/java/online/remind/remind/handler/EntityEventsRM.java
+++ b/src/main/java/online/remind/remind/handler/EntityEventsRM.java
@@ -37,14 +37,6 @@ import online.remind.remind.driveform.ModDriveFormsRM;
 import online.remind.remind.item.ModItemsRM;
 import online.remind.remind.lib.StringsRM;
 import online.remind.remind.network.PacketHandlerRM;
-import yesman.epicfight.skill.SkillContainer;
-import yesman.epicfight.skill.SkillSlots;
-import yesman.epicfight.skill.guard.GuardSkill;
-import yesman.epicfight.world.capabilities.EpicFightCapabilities;
-import yesman.epicfight.world.capabilities.entitypatch.player.PlayerPatch;
-import yesman.epicfight.world.capabilities.entitypatch.player.ServerPlayerPatch;
-import yesman.epicfight.world.capabilities.item.CapabilityItem;
-import yesman.epicfight.world.entity.eventlistener.HurtEvent;
 
 public class EntityEventsRM {
 
@@ -548,13 +540,6 @@ public class EntityEventsRM {
 		IGlobalCapabilitiesRM globalData = ModCapabilitiesRM.getGlobal(event.getEntity());
 		if (event.getEntity() instanceof Player){
 			Player player = (Player) event.getEntity();
-
-			PlayerPatch playerpatch = EpicFightCapabilities.getEntityPatch(player, PlayerPatch.class);
-			System.out.println(player.level().isClientSide() +" "+ playerpatch);
-			if (playerpatch != null) {
-				System.out.println( playerpatch.getSkill(SkillSlots.GUARD).getSkill() );
-			}
-
 
 			if (1 == globalData.getAutoLifeActive()){
 				if (player.getHealth() <= 0){

--- a/src/main/java/online/remind/remind/integration/epicfight/EpicFightEvents.java
+++ b/src/main/java/online/remind/remind/integration/epicfight/EpicFightEvents.java
@@ -1,0 +1,24 @@
+package online.remind.remind.integration.epicfight;
+
+import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.event.entity.living.LivingDeathEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import online.remind.remind.KingdomKeysReMind;
+import yesman.epicfight.skill.SkillSlots;
+import yesman.epicfight.world.capabilities.EpicFightCapabilities;
+import yesman.epicfight.world.capabilities.entitypatch.player.PlayerPatch;
+
+public class EpicFightEvents {
+
+    @SubscribeEvent
+    public void onDeath(LivingDeathEvent event) {
+        if (event.getEntity() instanceof Player) {
+            Player player = (Player) event.getEntity();
+            PlayerPatch playerpatch = EpicFightCapabilities.getEntityPatch(player, PlayerPatch.class);
+            System.out.println(player.level().isClientSide() + " " + playerpatch);
+            if (playerpatch != null) {
+                System.out.println(playerpatch.getSkill(SkillSlots.GUARD).getSkill());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Moves the EFM stuff in onDeath in EntityEventsRM into a separate class, can't just check if EFM is loaded because the import will still cause errors if it's missing.
This will fix the mod not working without EFM