### PR TITLE
Use correct namespace for tag and remove redundant KK ones

### DIFF
--- a/src/main/resources/data/kingdomkeys/tags/items/organization/roxas.json
+++ b/src/main/resources/data/kingdomkeys/tags/items/organization/roxas.json
@@ -1,36 +1,8 @@
 {
   "values": [
-    "kingdomkeys:kingdom_key",
-    "kingdomkeys:missing_ache",
-    "kingdomkeys:ominous_blight",
-    "kingdomkeys:abaddon_plasma",
-    "kingdomkeys:pain_of_solitude",
-    "kingdomkeys:sign_of_innocence",
-    "kingdomkeys:crown_of_guilt",
-    "kingdomkeys:abyssal_tide",
-    "kingdomkeys:leviathan",
-    "kingdomkeys:true_lights_flight",
-    "kingdomkeys:rejection_of_fate",
-    "kingdomkeys:midnight_roar",
-    "kingdomkeys:glimpse_of_darkness",
-    "kingdomkeys:total_eclipse",
-    "kingdomkeys:silent_dirge",
-    "kingdomkeys:lunar_eclipse",
-    "kingdomkeys:darker_than_dark",
-    "kingdomkeys:astral_blast",
-    "kingdomkeys:maverick_flare",
-    "kingdomkeys:twilight_blaze",
-    "kingdomkeys:omega_weapon",
-    "kingdomkeys:oathkeeper",
-    "kingdomkeys:two_become_one",
-    "kingdomkeys:oblivion",
-    "kingdomkeys:umbrella",
-    "kingdomkeys:aubade",
-    "kingdomkeys:wooden_stick",
-    "kkremind:elemental_crescendo",
-    "kkremind:pureblood",
-    "kkremind:gazing_omen"
-
+    "magicksaddon:elemental_crescendo",
+    "magicksaddon:pureblood",
+    "magicksaddon:gazing_omen"
   ],
   "replace": false
 }


### PR DESCRIPTION
you're still using magicksaddon not kkremind in 1.20.1 I think this is causing the crash with roxas, well I hope this is the reason cause otherwise I don't have any idea