### PR TITLE
fix crash when cactuar needles are killed by something

### DIFF
--- a/src/main/java/online/remind/remind/entity/projectile/CactuarNeedleProjectile.java
+++ b/src/main/java/online/remind/remind/entity/projectile/CactuarNeedleProjectile.java
@@ -79,9 +79,4 @@ public class CactuarNeedleProjectile extends Arrow {
     public void playerTouch(Player player) {
         // No pickup.
     }
-
-    @Override
-    protected ItemStack getDefaultPickupItem() {
-        return ItemStack.EMPTY;
-    }
 }


### PR DESCRIPTION
I noticed a crash report in your discord:
`java.lang.IllegalStateException: Cannot encode empty ItemStack`
and noticed when a the CactuarNeedleProjectile is killed by something, in this case was an explosion from DarkMineEntity, epic fight calls saveAdditionalSaveData which in AbstractArrow (which CactuarNeedleProjectile inherits from) saves the pickupItemStack and doesn't check whether the pickup is disallowed so this crash happens I've just removed the override setting it to an empty stack which means it will now be an Arrow but since pickup has been set to DISALLOWED it shouldn't matter. 